### PR TITLE
Moved unittest to dev_dependencies

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,6 +6,7 @@ homepage: https://github.com/Daegalus/formler
 environment:
   sdk: ">=1.0.0 <2.0.0"
 dependencies:
-  logging: ">=0.9.3 <=0.10.0"
-  unittest: ">=0.9.3 <=0.10.0"
   crypto: ">=0.9.1 <=0.10.0"
+  logging: ">=0.9.3 <=0.10.0"
+dev_dependencies:
+  unittest: ">=0.9.3 <=0.10.0"


### PR DESCRIPTION
I'm getting inconsistent dependencies errors for the unittest package, so I'm stuck at version 0.0.8 of formler. To resolve this, I think it will suffice to move the unittest dependency to dev_dependencies in pubspec!